### PR TITLE
Fix a bug in the include paths and doc it

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -33,4 +33,6 @@ cake watch
 
 ## Testing
 
-No tests yet!
+``` bash
+cake test
+```

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ precision: 5
 
 `precision` is a `Number` that will be used to determine how many digits after the decimal will be allowed. For instance, if you had a decimal number of `1.23456789` and a precision of `5`, the result will be `1.23457` in the final CSS.
 
+### includePaths
+```coffeescript
+includePaths: [ '/path/to/include', '/another/path/to/include]
+```
+`includePaths` is an `Array` of path `String`s to look for any `@import`ed files. It is recommended that you use this option if you are using the `data` option and have **any** `@import` directives, as otherwise [libsass] may not find your depended-on files.
+
 ### Bourbon
 
 ```coffeescript

--- a/src/sass.plugin.coffee
+++ b/src/sass.plugin.coffee
@@ -94,7 +94,7 @@ module.exports = (BasePlugin) ->
             return next(new Error(err))
 
         if fullDirPath
-          paths.push([fullDirPath])
+          paths.push(fullDirPath)
 
           if config.bourbon
             for path in bourbon


### PR DESCRIPTION
paths.push with an array obviously leads to having strangely nested arrays that libsass doesn't pick up. Mea Culpa. I also added a doc and fixed the contributing doc.