### PR TITLE
Update node-sass to 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "taskgroup": "~3.4.0",
-    "node-sass": "~1.2.3",
+    "node-sass": "~2.1.1",
     "node-bourbon": "~1.2.3",
     "node-neat": "~1.3.0"
   },


### PR DESCRIPTION
In order to resolve the issue with https://github.com/sass/node-sass/issues/653, node-sass needs to be upgraded to at least 2.0.1, so I'm upgrading to the current version of 2.1.1.

Running 'cake test' after upgrading node-sass was successful:
````
`--> cake test

> docpad-plugin-nodesass@2.5.1 test /tmp/docpad-plugin-nodesass
> node ./out/sass.test.js

nodesass plugin
nodesass plugin ➞  create
notice: If everyone who saw this message donated $1/week, maintaining DocPad would become sustainable: http://docpad.org/donate
nodesass plugin ➞  create ✔   
nodesass plugin ➞  load plugin nodesass
nodesass plugin ➞  load plugin nodesass ✔   
nodesass plugin ➞  generate
nodesass plugin ➞  generate ➞  action
OK
````