### PR TITLE
Removing generateBefore and TaskGroup.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "docpad": ">=6.3 <7"
   },
   "dependencies": {
-    "taskgroup": "~3.4.0",
     "node-sass": "~3.0.0",
     "node-bourbon": "~4.2.2",
     "node-neat": "~1.4.2"

--- a/src/sass.plugin.coffee
+++ b/src/sass.plugin.coffee
@@ -2,7 +2,6 @@
 module.exports = (BasePlugin) ->
   # Requires
   fs = require('fs')
-  {TaskGroup} = require('taskgroup')
   sass = require('node-sass')
   bourbon = require('node-bourbon').includePaths
   neat = require('node-neat').includePaths
@@ -19,17 +18,6 @@ module.exports = (BasePlugin) ->
       neat: false
       renderUnderscoreStylesheets: false
       sourceMap: false
-
-    # Generate Before
-    generateBefore: (opts,next) ->
-      # Prepare
-      config = @config
-
-      # Group
-      tasks = new TaskGroup().setConfig(concurrency:0).once('complete',next)
-
-      # Fire tasks
-      tasks.run()
 
     # Prevent underscore
     extendCollections: (opts) ->


### PR DESCRIPTION
I made a fork of this (because I have a hard dependency on using node-sass-import-once), and I noticed that this code was entirely unused.