### PR TITLE
Async core and import-once example

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,30 @@ renderUnderscoreStylesheets: false|true
 
 By default we prevent any SCSS stylesheets that filename starts with underscore character from being rendered and written to the output directory. This is to follow SCSS convention that such files are just intended to be included inside out stylesheets, and that they are not meant to be rendered by themselves. If you really want to, you can render the underscore stylesheets by setting the `renderUnderscoreStylesheets` option to `true` in your plugin's configuration.
 
+### import-once example
+
+The [node-sass-import-once](https://www.npmjs.com/package/node-sass-import-once) module speeds up rendering by only importing files once. It also adds a few additional features including automatically importing from `bower_components/`.
+
+Install it with
+
+```bash
+npm install --save node-sass-import-once
+```
+
+And then configure it by setting the `nodesass.options.importer` to the import-once module:
+
+```coffee
+    plugins:
+        nodesass:
+            options:
+                importer: require('node-sass-import-once')
+                importOnce: 
+                    index: true # @import 'foo'; will load foo/_index.scss if foo is a folder
+                    css: true # @import 'bar'; will import bar.css
+                    bower: true # automatically search bower_components directory for imports 
+			    
+```
+
 
 ## History
 [You can discover the history inside the `History.md` file](https://github.com/jking90/docpad-plugin-nodesass/blob/master/History.md)

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "Jimmy King <hello@jimmyking.me> (https://github.com/jking90)",
     "Jan Kolkmeier <jankolkmeier@gmail.com> (https://github.com/jouz)",
     "Benjamin Lupton <b@lupton.cc> (https://github.com/balupton)",
-    "Johannes Troeger (https://github.com/johannestroeger)"
+    "Johannes Troeger (https://github.com/johannestroeger)",
+    "Nathan Friedly (http://nfriedly.com/)"
   ],
   "bugs": {
     "url": "https://github.com/jking90/docpad-plugin-nodesass/issues"

--- a/package.json
+++ b/package.json
@@ -41,9 +41,10 @@
     "docpad": ">=6.3 <7"
   },
   "dependencies": {
-    "node-sass": "~3.0.0",
+    "async": "^1.4.2",
     "node-bourbon": "~4.2.2",
-    "node-neat": "~1.4.2"
+    "node-neat": "~1.4.2",
+    "node-sass": "~3.0.0"
   },
   "devDependencies": {
     "coffee-script": "^1.9.2",

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
   ],
   "contributors": [
     "Merrick Christensen <merrick.christensen@gmail.com> (https://github.com/iammerrick)",
+    "Nathan Friedly (http://nfriedly.com/)",
     "Jimmy King <hello@jimmyking.me> (https://github.com/jking90)",
     "Jan Kolkmeier <jankolkmeier@gmail.com> (https://github.com/jouz)",
     "Benjamin Lupton <b@lupton.cc> (https://github.com/balupton)",
-    "Johannes Troeger (https://github.com/johannestroeger)",
-    "Nathan Friedly (http://nfriedly.com/)"
+    "Johannes Troeger (https://github.com/johannestroeger)"
   ],
   "bugs": {
     "url": "https://github.com/jking90/docpad-plugin-nodesass/issues"


### PR DESCRIPTION
Makes codebase fully async, and also adds an example to the readme for working with the import-once module.

Note: this is branched off of my earlier PR (#34) because I believe that there would be conflicts otherwise. However, I'm targeting `develop` with this PR.

Fixes #35 