### PR TITLE
exclude node-sass v3.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "colors": "^1.1.2",
     "node-bourbon": "^4.2.3",
     "node-neat": "^1.7.2",
-    "node-sass": "^3.2.0"
+    "node-sass": ">=3.2.0 <=3.4.0 || >=4.4.2 <4.0.0"
   },
   "devDependencies": {
     "coffee-script": "^1.9.2",


### PR DESCRIPTION
https://github.com/sass/node-sass/issues/1219 is killing me. Broken in v3.4.1 and expected to be fixed in v3.4.2